### PR TITLE
feat(jira-close-merged): skill to close Jira tickets from git commits

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -186,6 +186,16 @@
       },
       "source": "./plugins/review-push-loop",
       "category": "development"
+    },
+    {
+      "name": "jira-close-merged",
+      "description": "Scan the git log for Jira ticket IDs and transition any non-Done tickets to Done using the Atlassian MCP",
+      "version": "1.0.0",
+      "author": {
+        "name": "Jaehyun Yeom"
+      },
+      "source": "./plugins/jira-close-merged",
+      "category": "development"
     }
   ]
 }

--- a/plugins/jira-close-merged/.claude-plugin/plugin.json
+++ b/plugins/jira-close-merged/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "jira-close-merged",
+  "version": "1.0.0",
+  "description": "Scan the git log for Jira ticket IDs and transition any non-Done tickets to Done using the Atlassian MCP",
+  "author": {
+    "name": "Jaehyun Yeom"
+  },
+  "repository": "https://github.com/jaeyeom/claude-toolbox",
+  "license": "MIT",
+  "keywords": ["jira", "atlassian", "mcp", "git", "workflow", "automation"]
+}

--- a/plugins/jira-close-merged/README.md
+++ b/plugins/jira-close-merged/README.md
@@ -1,0 +1,50 @@
+# jira-close-merged
+
+Claude Code skill for syncing Jira tickets with merged git commits using the
+Atlassian MCP.
+
+## Prerequisites
+
+- Atlassian MCP connected (`mcp__claude_ai_Atlassian__*` tools available)
+- Git repository with Jira ticket IDs referenced in commit messages
+
+## Installation
+
+```text
+/plugin marketplace add jaeyeom/claude-toolbox
+
+/plugin install jira-close-merged
+```
+
+## Skills
+
+### Closing merged tickets
+
+- `/jira-close-merged:jira-close-merged` — Scan the git log for Jira ticket IDs and transition any non-Done tickets to Done
+- `/jira-close-merged:jira-close-merged PROJ` — Limit scan to a specific project key (e.g. `PROJ`)
+
+## How it works
+
+1. Scans `git log` (last 50 commits by default) for Jira ticket IDs matching
+   `[A-Z]+-\d+` (e.g. `PROJ-123`, `TEAM-456`).
+2. Looks up each ticket's current status via the Atlassian MCP.
+3. Skips tickets already in the "Done" status category.
+4. Transitions all remaining tickets to Done in one pass.
+5. Reports a summary table with per-ticket results.
+
+## Example usage
+
+After a batch of PRs lands on main:
+
+```
+/jira-close-merged:jira-close-merged PROJ
+```
+
+Or to check all project keys in the last 100 commits:
+
+```
+/jira-close-merged:jira-close-merged
+```
+
+(The skill will show you which project keys it found and ask you to confirm
+before making any changes.)

--- a/plugins/jira-close-merged/skills/jira-close-merged/SKILL.md
+++ b/plugins/jira-close-merged/skills/jira-close-merged/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: jira-close-merged
+description: >
+  Marks Jira tickets as Done when their commits have been merged into the
+  current branch. Use whenever the user wants to sync Jira with merged
+  commits — e.g. "mark done", "close tickets from commits", "sync Jira
+  with merged PRs", "any Jira tickets to close?", or after a batch of PRs
+  lands. Works with any Jira project key.
+---
+
+# Jira: Close Merged Tickets
+
+Scans the git log for Jira ticket IDs, checks their current status, and
+transitions any non-Done tickets to Done.
+
+## Steps
+
+### 1. Collect ticket IDs
+
+Run the following, substituting the project key(s) the user specifies (or
+ask if unclear):
+
+```bash
+git log --oneline -50 | grep -oP '\b[A-Z]+-\d+\b' | sort -u
+```
+
+Adjust the commit depth (default 50) and project key pattern to match the
+user's context. If the user says "last 100 commits" or names a specific
+project key, use that. If the user specifies a project key like `PROJ`,
+use `grep -oP '\bPROJ-\d+\b'` instead.
+
+### 2. Look up Jira status
+
+Use `searchJiraIssuesUsingJql` with a query like:
+
+```
+issueKey in (PROJECT-1, PROJECT-2, ...)
+```
+
+Request only `summary`, `status`, and `assignee` fields to keep the
+response small. Use `getAccessibleAtlassianResources` to resolve the
+cloud ID if you don't already have it in context.
+
+### 3. Identify tickets to close
+
+Skip tickets already in a "Done" status category (where
+`status.statusCategory.key == "done"`). Report them as "already done"
+so the user knows they were checked.
+
+### 4. Get the Done transition ID
+
+Call `getTransitionsForJiraIssue` on any one of the tickets to be
+transitioned. Find the transition whose `to.statusCategory.key` is
+`"done"` and note its `id`.
+
+If there are no non-Done tickets, skip this step and go to step 6.
+
+### 5. Transition all non-Done tickets in parallel
+
+Call `transitionJiraIssue` for every ticket identified in step 3, all at
+once. If a ticket can't be transitioned (e.g. blocked by a required
+field), report it as "skipped" with the error rather than failing the
+whole run.
+
+### 6. Report results
+
+Show a compact summary table:
+
+| Ticket | Summary (truncated to ~40 chars) | Result |
+|--------|----------------------------------|--------|
+| X-123  | Short summary...                 | Done ✓ |
+| X-124  | Another ticket...                | already done |
+| X-125  | Blocked ticket...                | skipped: <reason> |
+
+List counts at the end: "Transitioned N ticket(s), M already done, K skipped."
+
+## Notes
+
+- If the user doesn't specify a project key, scan for any `[A-Z]+-\d+`
+  pattern (bare ticket IDs like `PROJ-123` in commit messages). Present
+  the unique project keys found and ask the user to confirm which ones to
+  process before proceeding — avoid accidentally closing tickets from
+  unrelated projects.
+- Commit depth defaults to 50; the user can override it (e.g. "last 100
+  commits", "since last release tag").
+- Requires the Atlassian MCP (`mcp__claude_ai_Atlassian__*` tools) to be
+  connected.


### PR DESCRIPTION
## Summary

- Adds a new `jira-close-merged` plugin with a skill that scans `git log` for Jira ticket IDs and transitions any non-Done tickets to Done via the Atlassian MCP
- Registers the plugin in `marketplace.json`

## What the skill does

1. Scans the last 50 git commits (configurable) for Jira ticket IDs matching `[A-Z]+-\d+`
2. Looks up each ticket's status via `searchJiraIssuesUsingJql`
3. Skips tickets already in the "Done" status category
4. Gets the Done transition ID via `getTransitionsForJiraIssue`
5. Transitions all non-Done tickets in parallel via `transitionJiraIssue`
6. Reports a compact summary table with per-ticket results

Requires the Atlassian MCP to be connected.

Resolves #23

## Test plan

- [ ] Install the plugin: `/plugin install jira-close-merged`
- [ ] Run `/jira-close-merged:jira-close-merged` in a repo with Jira ticket IDs in recent commits
- [ ] Confirm the skill identifies tickets, skips already-Done ones, and transitions the rest
- [ ] Run `/jira-close-merged:jira-close-merged PROJ` to verify project key filtering works
- [ ] Confirm the summary table shows correct results (Done ✓, already done, skipped)