### PR TITLE
feat(gh-issue-resolver): follow issue plan; two-yes deviation gates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -99,8 +99,8 @@
     },
     {
       "name": "gh-issue-resolver",
-      "description": "Resolve GitHub issues using the gh CLI with dependency checking, self-assignment, codebase investigation, and automatic commits",
-      "version": "1.1.0",
+      "description": "Resolve GitHub issues using the gh CLI, following the issue plan and acceptance criteria, with approval gates when the plan must change",
+      "version": "1.2.0",
       "author": {
         "name": "Jaehyun Yeom"
       },

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ These plugins work together to create a reliable development workflow:
 Add the task-management layer on top:
 - `next-action` finds the next item worth doing.
 - `todo` tracks local work.
-- `gh-issue-resolver` can take an issue from investigation through commit.
+- `gh-issue-resolver` can take an issue from its written plan through commit, stopping when the plan must change.
 
 ## Quick Start
 

--- a/plugins/gh-issue-resolver/.claude-plugin/plugin.json
+++ b/plugins/gh-issue-resolver/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gh-issue-resolver",
-  "version": "1.1.0",
-  "description": "Resolve GitHub issues using the gh CLI with dependency checking, self-assignment, codebase investigation, and automatic commits",
+  "version": "1.2.0",
+  "description": "Resolve GitHub issues using the gh CLI, following the issue plan and acceptance criteria, with approval gates when the plan must change",
   "author": {
     "name": "Jaehyun Yeom"
   },

--- a/plugins/gh-issue-resolver/README.md
+++ b/plugins/gh-issue-resolver/README.md
@@ -4,12 +4,14 @@ A Claude Code skill for resolving GitHub issues end-to-end using the `gh` CLI.
 
 ## What It Does
 
-- Reads a GitHub issue and understands the requirements
+- Reads a GitHub issue and treats its plan as the execution contract
+- Uses the issue's acceptance criteria as the definition of done
 - Checks for blocking sub-issues or task list dependencies
 - Self-assigns the issue and labels it "in progress"
 - Searches the codebase for references to the issue number (TODOs, FIXMEs, etc.)
-- Investigates and implements the fix
-- Reviews changes for quality (no unnecessary comments, no debug code)
+- Executes the written plan; stops and asks before any deviation
+- After an approved deviation, proposes a surgical issue-body edit and waits for a second yes
+- Reviews changes against the acceptance criteria
 - Commits with a message that references the issue for auto-close on merge
 
 ## Prerequisites
@@ -37,12 +39,13 @@ Resolve GitHub issue #42
 
 ## Workflow
 
-1. **Read** — Fetches the issue via `gh issue view`
+1. **Read** — Fetches the issue via `gh issue view` and extracts the plan and acceptance criteria
 2. **Block check** — Parses body for unchecked task list items (`- [ ] #N`); rejects if any are open
 3. **In progress** — Assigns to self, adds "in progress" label
-4. **Investigate** — Searches codebase with `rg` for `#N` and `issues/N` references
-5. **Resolve** — Makes code changes following the issue description and TODO pointers
-6. **Review** — Checks for unnecessary comments and code quality
-7. **Commit** — Creates a commit with `Resolves #N` for automatic issue closure on merge
+4. **Execute** — Follows the written plan; codebase search locates planned change sites
+5. **Deviation gate** — If reality differs from the plan, stops and waits for a first yes
+6. **Issue update** — After an approved deviation, proposes a surgical body edit and waits for a second yes
+7. **Review** — Checks completeness against the acceptance criteria
+8. **Commit** — Creates a commit with `Resolves #N` for automatic issue closure on merge
 
 The issue is intentionally left open — it closes automatically when the fix is merged.

--- a/plugins/gh-issue-resolver/skills/gh-issue-resolver/SKILL.md
+++ b/plugins/gh-issue-resolver/skills/gh-issue-resolver/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: gh-issue-resolver
-description: Resolve a GitHub issue end-to-end using the gh CLI. Checks for blocking sub-issues/dependencies, self-assigns, investigates the codebase, makes changes, reviews code, and commits. Use when asked to resolve, fix, or work on a GitHub issue.
+description: Resolve a GitHub issue end-to-end using the gh CLI. Use when asked to resolve, fix, or work on a GitHub issue, when the issue has a written plan or acceptance criteria, or when implementation starts to diverge from that plan.
 argument-hint: "<issue-number>"
 autouse: false
 ---
 
 # GitHub Issue Resolver
 
-Resolve a GitHub issue by investigating the codebase, making changes, and committing the fix.
+Resolve a GitHub issue by executing the issue's plan, meeting its acceptance
+criteria, and committing the fix.
+
+The issue's plan is the execution contract. Its acceptance criteria are the
+definition of done. Do not invent a competing approach.
 
 ## Prerequisites
 
@@ -24,9 +28,19 @@ Fetch the issue details:
 gh issue view $ARGUMENTS --json number,title,body,state,labels,assignees
 ```
 
-Read the title, body, and labels carefully. Understand what is being asked.
-
 If the issue is already closed, inform the user and stop.
+
+Extract the **plan** and **acceptance criteria** as the contract:
+
+| Body has | Treat as the plan |
+|----------|-------------------|
+| A heading such as Plan, Proposed design, Proposed behavior, Suggested approach, or Scope | That section |
+| None of those headings | The whole body |
+
+| Body has | Treat as acceptance criteria |
+|----------|------------------------------|
+| Acceptance criteria or Requirements (checkboxes or a MUST/should list) | That section |
+| Neither | The stated outcome in the title and body |
 
 ### Step 2 — Check for blocking dependencies
 
@@ -71,7 +85,7 @@ gh label create "in progress" --description "Work is actively underway" --color 
 If label creation fails (e.g., insufficient permissions), skip labeling and
 proceed — assignment alone is sufficient to signal progress.
 
-### Step 4 — Investigate and resolve the issue
+### Step 4 — Execute the plan
 
 Search the codebase for references to the issue number:
 
@@ -88,17 +102,75 @@ Replace `<issue-number>` with the actual number from `$ARGUMENTS`.
 - **Other references** (documentation, changelogs, test comments) provide
   context about the issue.
 
-If no references are found, rely on the issue description to understand what
-needs to change. Investigate relevant files, trace the code path, and implement
-the fix as described.
+Use those searches to **locate the planned change sites**, not to replace the
+plan. Implement the plan as written. After each meaningful step, compare what
+you are doing to the plan and the acceptance criteria.
+
+### Step 4a — Deviation gate (first yes)
+
+STOP before continuing if any of these is true:
+
+- the planned approach is wrong or incomplete
+- a different implementation is needed (including a better existing helper)
+- a planned step or file should be skipped
+- extra work not in the plan is needed
+- a plan assumption is false, or an unknown appears
+- an acceptance criterion cannot be met as written
+
+Present, then wait for an explicit yes:
+
+1. What the plan / acceptance criteria said
+2. What you found
+3. The proposed change
+
+Do **not** implement the deviation until the user explicitly approves it.
+
+**No exceptions:**
+
+- Do not treat "intent is satisfied" as permission to change the plan
+- Do not treat "the plan is a means, not the requirement" as permission
+- Do not proceed because the user said "just finish, don't wait"
+- Do not implement first and mention the change later
+- A better existing helper is still a deviation
+
+### Step 4b — Issue update (second yes)
+
+After an approved deviation is implemented, propose a **surgical** issue-body
+edit so the plan and acceptance criteria match what was actually done.
+
+The proposal is:
+
+- a unified-diff (or before/after) of **only** the sentences or bullets that
+  no longer match
+- still-valid investigation left untouched
+- acceptance-criteria wording updated only if the criteria themselves changed
+
+Show that exact edit. Do **not** run `gh issue edit` until the user explicitly
+approves that edit. If they decline, leave the issue body as-is.
+
+```bash
+gh issue edit $ARGUMENTS --body-file <updated-body>
+```
+
+**No exceptions:**
+
+- The first yes approved the approach, not the issue edit
+- "Bookkeeping", "the record is lying", or review starting soon does not skip
+  the second yes
+- Do not rewrite the whole issue body
+- Do not edit first and mention it after
 
 ### Step 5 — Review the code changes
 
 Before committing, review all changes you made:
 
-1. Ensure changes are correct and complete relative to the issue description.
-2. Remove unnecessary comments that merely restate what the code does.
-3. Verify no debug code, temporary logging, or unrelated changes are included.
+1. Ensure changes are correct and complete relative to the **acceptance
+   criteria** (or the contract from Step 1 if there is no AC section).
+2. Confirm every implemented deviation was approved (first yes) and that any
+   issue-body edit was either approved (second yes) or skipped because the
+   user declined.
+3. Remove unnecessary comments that merely restate what the code does.
+4. Verify no debug code, temporary logging, or unrelated changes are included.
 
 ### Step 6 — Commit the changes
 
@@ -133,3 +205,25 @@ this step.
 Do **not** close the issue. The issue will be closed automatically when the
 commit is merged (via the `Resolves #N` reference), or the user can close it
 manually after review.
+
+## Red Flags — STOP
+
+- "The plan is a means, not the requirement"
+- "Intent is satisfied either way"
+- "User said don't wait" / review is in N minutes
+- Implementing a different approach, then mentioning it in the commit or PR
+- `gh issue edit` after the first yes without showing the exact diff
+- "Updating the issue is just bookkeeping"
+- Rewriting the whole issue body
+
+## Rationalizations
+
+| Excuse | Reality |
+|--------|---------|
+| "The plan is a means; intent is satisfied" | The written plan is the contract. Changing it needs the first yes. |
+| "User said just finish, don't wait" | Deviation still needs a yes. Message them and stop. |
+| "I'll mention it in the commit / later" | That is implementing first. Stop. |
+| "A better helper is not really a plan change" | Different files or approach = deviation. First yes. |
+| "They already said yes to the approach" | That was the first yes. The issue edit needs a second yes. |
+| "Asking again is pedantic / the issue is lying" | Propose the exact diff and wait. Do not edit. |
+| "I'll rewrite the whole issue so it's accurate" | Surgical only: change the sentences that no longer match. |


### PR DESCRIPTION
## Summary

- `gh-issue-resolver` now treats the issue's **plan** as the execution contract and its **acceptance criteria** as the definition of done
- Codebase search is only for locating planned change sites, not inventing a competing approach
- **First yes:** if execution would diverge from the plan (wrong assumption, better helper, skipped step, extra work, unknown, unmet AC), stop and wait for approval before implementing
- **Second yes:** after an approved deviation is implemented, propose a surgical issue-body edit and wait for another yes before `gh issue edit`
- Bump plugin version to 1.2.0

## Test plan

- [ ] Read `plugins/gh-issue-resolver/skills/gh-issue-resolver/SKILL.md` and confirm the two gates are hard stops
- [ ] `/gh-issue-resolver N` on an issue whose plan is still correct — should execute the plan without asking to re-plan
- [ ] Mid-issue, surface a better existing helper or a stale assumption — should stop and present plan vs found vs proposed change, not implement
- [ ] After approving a deviation, confirm it proposes a surgical diff and does **not** run `gh issue edit` until a second yes
- [ ] Decline the issue edit — issue body stays unchanged
- [ ] `make validate` (or `./scripts/validate-marketplace.sh`) still passes